### PR TITLE
Cook 1106

### DIFF
--- a/templates/centos/bluepill_init.erb
+++ b/templates/centos/bluepill_init.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Author: Jamie Winsor (<jwinsor@riotgames.com>)
+# Author: Jamie Winsor (<jamie@vialstudios.com>)
 #
 # chkconfig: 345 99 1
 # Description: Bluepill loader for <%= @service_name %>


### PR DESCRIPTION
The loader that I previously wrote to automatically start bluepill services on Centos does not work on Centos 5.x, only Centos 6.x.

This is because a description field is required for the init script to be considered "valid" by chkconfig.

A description field should be added to satisfy this requirement.
