### PR TITLE
use an integer for bluepill group instead of string

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@ default["bluepill"]["bin"] = "#{languages[:ruby][:bin_dir]}/bluepill"
 default["bluepill"]["logfile"] = "/var/log/bluepill.log"
 default["bluepill"]["pid_dir"] = "/var/run/bluepill"
 default["bluepill"]["state_dir"] = "/var/lib/bluepill"
-default["bluepill"]["group"] = "0"
+default["bluepill"]["group"] = 0
 
 case platform
 when "arch"


### PR DESCRIPTION
Files written by the Bluepill provder by default write with the group "0".

On Centos 5 nodes this is an issue because the group of the string "0" is not found. This default value should instead be the integer 0.

Generated at 2012-03-15 17:00:30 -0700
Chef::Exceptions::GroupIDNotFound: template[/etc/init.d/bluepill-chef-client](/var/cache/chef/cookbooks/bluepill/providers/service.rb line 36) had an error: Chef::Exceptions::GroupIDNotFound: cannot determine group id for '0', does the group exist on this system?
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/file_access_control.rb:104:in `rescue in target_gid'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/file_access_control.rb:94:in`target_gid'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/file_access_control.rb:108:in `set_group'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/file_access_control.rb:56:in`set_all'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/provider/template.rb:89:in `set_all_access_controls'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/provider/template.rb:46:in`block in action_create'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/mixin/template.rb:48:in `block in render_template'
/usr/local/lib/ruby/1.9.1/tempfile.rb:320:in`open'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/mixin/template.rb:45:in `render_template'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/provider/template.rb:99:in`render_with_context'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/provider/template.rb:39:in `action_create'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource.rb:440:in`run_action'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/runner.rb:45:in `run_action'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/runner.rb:81:in`block (2 levels) in converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/runner.rb:81:in `each'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/runner.rb:81:in`block in converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource_collection.rb:94:in `block in execute_each_resource'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource_collection/stepable_iterator.rb:116:in`call'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource_collection/stepable_iterator.rb:85:in`step'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource_collection/stepable_iterator.rb:55:in`each_with_index'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/resource_collection.rb:92:in `execute_each_resource'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/runner.rb:76:in`converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/client.rb:312:in `converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/client.rb:160:in`run'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/application/client.rb:239:in `block in run_application'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/application/client.rb:229:in`loop'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/application/client.rb:229:in `run_application'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/lib/chef/application.rb:67:in`run'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.8/bin/chef-client:26:in `<top (required)>'
/usr/local/bin/chef-client:19:in`load'
/usr/local/bin/chef-client:19:in `<main>'
