### PR TITLE
Update test/kitchen/cookbooks/bluepill_test/attributes/default.rb

### DIFF
--- a/test/kitchen/cookbooks/bluepill_test/attributes/default.rb
+++ b/test/kitchen/cookbooks/bluepill_test/attributes/default.rb
@@ -2,4 +2,4 @@ require 'uuidtools'
 
 default['bluepill_test']['service_name'] = "test_app"
 default['bluepill_test']['tcp_server_listen_port'] = 1234
-default['bluepill_test']['secret'] = UUIDTools::UUID.random_create
+default['bluepill_test']['secret'] = UUIDTools::UUID.random_create.to_s


### PR DESCRIPTION
Switch to (hopefully) 1.8.x compatible UUID implementation used by Chef.
