### PR TITLE
 COOK-1730 Add ability to specify which version of bluepill to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Default locations for bluepill are in "FHS compliant" locations.
 * `node["bluepill"]["pid_dir"]` - Location of pidfiles, default "/var/run/bluepill"
 * `node["bluepill"]["state_dir"]` - Location of state directory, default "/var/lib/bluepill"
 * `node["bluepill"]["init_dir"]` - Location of init script directory, default selected by platform.
+* `node["bluepill"]["version"]` - Version of bluepill to install, default is latest.
 
 Resources/Providers
 ===================

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,9 @@
 #
 
 gem_package "i18n"
-gem_package "bluepill"
+gem_package "bluepill" do
+  version node["bluepill"]["version"] if node["bluepill"]["version"]
+end
 
 [
   node["bluepill"]["conf_dir"],


### PR DESCRIPTION
I Added a node["bluepill"]["version"] that let's one specify which version of bluepill to install.

The one thing I'm not sure about is whether the version attribute should have a default value, or if it should be nil when not specified. I don't know if there is a way this is normally done.
