### PR TITLE
[COOK-3503] Supporting why-run for the bluepill_service LWRP.

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -23,81 +23,92 @@ require 'chef/mixin/language'
 
 include Chef::Mixin::ShellOut
 
+def whyrun_supported?
+  true
+end
+
 action :enable do
   config_file = ::File.join(node['bluepill']['conf_dir'],
                             "#{new_resource.service_name}.pill")
   unless @current_resource.enabled
-    link "#{node['bluepill']['init_dir']}/#{new_resource.service_name}" do
-      to node['bluepill']['bin']
-      only_if { ::File.exists?(config_file) }
-    end
-    case node['platform_family']
-    when "rhel", "fedora", "freebsd"
-      template "#{node['bluepill']['init_dir']}/bluepill-#{new_resource.service_name}" do
-        source "bluepill_init.#{node['platform_family']}.erb"
-        cookbook "bluepill"
-        owner "root"
-        group node['bluepill']['group']
-        mode "0755"
-        variables(
-                  :service_name => new_resource.service_name,
-                  :config_file => config_file
-                  )
+    converge_by("enable #{ @new_resource }") do
+      link "#{node['bluepill']['init_dir']}/#{new_resource.service_name}" do
+        to node['bluepill']['bin']
+        only_if { ::File.exists?(config_file) }
       end
-
-      service "bluepill-#{new_resource.service_name}" do
-        action [ :enable ]
+      case node['platform_family']
+      when "rhel", "fedora", "freebsd"
+        template "#{node['bluepill']['init_dir']}/bluepill-#{new_resource.service_name}" do
+          source "bluepill_init.#{node['platform_family']}.erb"
+          cookbook "bluepill"
+          owner "root"
+          group node['bluepill']['group']
+          mode "0755"
+          variables(
+                    :service_name => new_resource.service_name,
+                    :config_file => config_file
+                    )
+        end
+     
+        service "bluepill-#{new_resource.service_name}" do
+          action [ :enable ]
+        end
       end
     end
-    new_resource.updated_by_last_action(true)
   end
 end
 
 action :load do
   unless @current_resource.running
-    shell_out!(load_command)
-    new_resource.updated_by_last_action(true)
+    converge_by("load #{ @new_resource }") do
+      shell_out!(load_command)
+    end
   end
 end
 
 action :reload do
-  shell_out!(stop_command) if @current_resource.running
-  shell_out!(load_command)
-  new_resource.updated_by_last_action(true)
+  converge_by("reload #{ @new_resource }") do
+    shell_out!(stop_command) if @current_resource.running
+    shell_out!(load_command)
+  end
 end
 
 action :start do
   unless @current_resource.running
-    shell_out!(start_command)
-    new_resource.updated_by_last_action(true)
+    converge_by("start #{ @new_resource }") do
+      shell_out!(start_command)
+    end
   end
 end
 
 action :disable do
   if @current_resource.enabled
-    file "#{node['bluepill']['conf_dir']}/#{new_resource.service_name}.pill" do
-      action :delete
+    converge_by("disable #{ @new_resource }") do
+      file "#{node['bluepill']['conf_dir']}/#{new_resource.service_name}.pill" do
+        action :delete
+      end
+      link "#{node['bluepill']['init_dir']}/#{new_resource.service_name}" do
+        action :delete
+      end
     end
-    link "#{node['bluepill']['init_dir']}/#{new_resource.service_name}" do
-      action :delete
-    end
-    new_resource.updated_by_last_action(true)
   end
 end
 
 action :stop do
   if @current_resource.running
-    shell_out!(stop_command)
-    new_resource.updated_by_last_action(true)
+    converge_by("stop #{ @new_resource }") do
+      shell_out!(stop_command)
+    end
   end
 end
 
 action :restart do
   if @current_resource.running
-    Chef::Log.debug "Restarting #{new_resource.service_name}"
-    shell_out!(restart_command)
-    new_resource.updated_by_last_action(true)
-    Chef::Log.debug "Restarted #{new_resource.service_name}"
+    converge_by("restart #{ @new_resource }") do
+      Chef::Log.debug "Restarting #{new_resource.service_name}"
+      shell_out!(restart_command)
+      Chef::Log.debug "Restarted #{new_resource.service_name}"
+    end
   end
 end
 


### PR DESCRIPTION
This commit implements `why-run` support for the `bluepill_service` LWRP.

I found that on converge, the actions taken by the LWRP (if any were taken at all)
go unreported - this stands out when you run `chef-client` with `-F doc`. 
While the resource is marked as updated and picked up by report handlers,
it isn't clear what changed (did the bluepill-based service reload, or restart?)

I also found that implementing `why-run` support  has the added effect of 'fixing' this - 
it causes the actual actions taken by the LWRP `bluepill_service` to 
be reported during a converge:

To illustrate, assume we have in a `foo` cookbook something like:

``` ruby
# Keep some foo daemon running - with bluepill

template '/etc/bluepill/foo.pill' do
  source 'foo.pill.erb'
  notifies :reload, 'bluepill_service[foo]'
end

bluepill_service "foo" do
  action [:enable, :load, :start]
end

# we want to restart foo when this file changes.
template '/etc/foo.conf' do
  source 'foo.conf.erb'
  notifies :restart, 'bluepill_service[foo]'  
  # bluepill_service[foo] properly restarts if this file changes,
  # but this fact isn't clearly reported.
end
```

Assume we do a converge and the contents of `foo.conf` are updated. In either case, `bluepill_service` is properly restarted as expected, but this fact isn't clearly reported:

(without why-run support)

```
$ chef-client -F doc
# .. output ...
Recipe: foo::default
  * bluepill_service[foo] action restart
    (nothing!)
```

(if why-run were supported )

```
$ chef-client -F doc
# .. output ...
Recipe: foo::default
  * bluepill_service[foo] action restart
    - restart bluepill_service[foo]
```
