### PR TITLE
Flipping the status and service around fixes service_running?

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -128,7 +128,7 @@ end
 protected
 
 def status_command
-  "#{node['bluepill']['bin']} #{new_resource.service_name} status"
+  "#{node['bluepill']['bin']} status #{new_resource.service_name}"
 end
 
 def load_command


### PR DESCRIPTION
The stdout from shell_out was just a newline, so bluepill never stopped my services.
