### PR TITLE
Clear up some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+

--- a/README.md
+++ b/README.md
@@ -47,13 +47,9 @@ Be sure to include the bluepill recipe in the run list to ensure that the gem an
 
 If the default directory locations in the attributes/default.rb aren't what you want, change them by setting them either in the attributes file itself, or create attributes in a role applied to any systems that will use bluepill.
 
-Example pill template resource and .erb file:
+Bluepill uses configuration files named my_app.pill that are stored in `/etc/bluepill`.  Here is an example pill:
 
 ```ruby
-template '/etc/bluepill/my_app.pill' do
-  source 'my_app.pill.erb'
-end
-
 Bluepill.application('my_app') do |app|
   app.process('my_app') do |process|
     process.pid_file = '/var/run/my_app.pid'
@@ -61,8 +57,15 @@ Bluepill.application('my_app') do |app|
   end
 end
 ```
+You can create this file with `cookbook_file` as follows:
 
-See bluepill's documentation for more information on creating pill templates.
+```ruby
+cookbook_file '/etc/bluepill/my_app.pill' do
+  source 'my_app.pill'
+end
+```
+
+See bluepill's [documentation](https://github.com/bluepill-rb/bluepill#config) for more information on creating pill templates.
 
 ## Testing
 This cookbook has the following [ChefSpec custom matchers](https://github.com/sethvargo/chefspec#packaging-custom-matchers) defined:


### PR DESCRIPTION
### Description

I have never used bluepill before and found the documentation a little tricky.  Here is my attempt at clearing that up.  To me the section on what a pill looked like appeared to be chef code.  I went upstream and found that it was just ruby code masquerading as a config file and then it all made sense.  Hopefully splitting that code block into two separate sections clears that up for others and saves a few steps.

While I was at it, I noticed that there weren't any variables that changed inside of the pill file, so it didn't "need" to be a template.  Probably somebody will need a template, but I have a feeling they know who they are.

Good stuff, just trying to help.

### Issues Resolved

Cleared up some documentation

### Check List

- [N/A] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Steve McGrane <temporarilyoffline@gmail.com>