### PR TITLE
Fixes a typo in LSB init which triggers an abort during deploy

### DIFF
--- a/templates/default/bluepill_init.lsb.erb
+++ b/templates/default/bluepill_init.lsb.erb
@@ -4,7 +4,7 @@
 # Provides: <%= @service_name %>
 # Required-Start:
 # Required-Stop:
-# Defalt-Start: 2 3 4 5
+# Default-Start: 2 3 4 5
 # Default-Stop: 0 1 2 6
 # Description: Bluepill loader for <%= @service_name %>
 ### END INIT INFO


### PR DESCRIPTION
### Description

Corrects a typo in which Default-Start was written as Defalt-Start, triggering an error during deployment on Ubuntu 16.04.

### Issues Resolved


### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X ] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>