### PR TITLE
Removes a deprecated dependency 'chef/mixin/language'

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs bluepill gem and configures to manage services, includes bluepill_service LWRP'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.1.0'
+version '4.1.1'
 recipe 'bluepill::default', 'Installs bluepill rubygem and sets up management directories'
 
 depends 'rsyslog', '>= 2.0'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -20,8 +20,6 @@
 property :service_name, name_property: true
 property :variables, Hash
 
-require 'chef/mixin/language'
-
 action :start do
   unless service_running?
     converge_by("start #{new_resource.service_name}") do


### PR DESCRIPTION
### Description

Removes a deprecated dependency 'chef/mixin/language'

### Issues Resolved

https://github.com/chef-cookbooks/bluepill/issues/36

### Check List
I tried to run the test suite. It seems to complete fine until testing on OpenSuse Leap, where it fails with an unrelated error (something about having guest additions installed). I cannot dedicate more time to troubleshooting this. I need the fix for some of our projects, and we can continue using our forked version for the time being. 

- [] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
